### PR TITLE
fix: docker version

### DIFF
--- a/CodeEditorStack.template.yaml
+++ b/CodeEditorStack.template.yaml
@@ -974,7 +974,7 @@ Resources:
               sudo chmod a+r /etc/apt/keyrings/docker.asc
               echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
               sudo apt update -qq
-              sudo apt install -y -qq docker-ce docker-ce-cli docker-buildx-plugin docker-compose-plugin
+              sudo apt install -y -qq docker-ce=5:20.10.24~3-0~ubuntu-jammy docker-ce-cli=5:20.10.24~3-0~ubuntu-jammy docker-buildx-plugin docker-compose-plugin
           fi
 
           # install golang

--- a/src/lifecycle_config.py
+++ b/src/lifecycle_config.py
@@ -88,7 +88,7 @@ if [ -z `which docker` ]; then
     sudo chmod a+r /etc/apt/keyrings/docker.asc
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     sudo apt update -qq
-    sudo apt install -y -qq docker-ce docker-ce-cli docker-buildx-plugin docker-compose-plugin
+    sudo apt install -y -qq docker-ce=5:20.10.24~3-0~ubuntu-jammy docker-ce-cli=5:20.10.24~3-0~ubuntu-jammy docker-buildx-plugin docker-compose-plugin
 fi
 
 # install golang


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Set docker version to 20.0.X which is only supported version for SageMaker Studio.
https://docs.aws.amazon.com/sagemaker/latest/dg/studio-updated-local-get-started.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
